### PR TITLE
Add security logging file support

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -218,7 +218,7 @@ bool
 get_security_logging_file_path(
     std::string & security_logging_file_path, const char * node_secure_root)
 {
-  const char * file_names = {"security_logging.xml"};
+  const char * file_names = "logging.xml";
 
   std::string file_prefix("file://");
 


### PR DESCRIPTION
Add support for finding and loading the security logging file and forward parameters to fastrtps.

This goes hand in hand with the changes in FastRTPS at https://github.com/ubuntu-robotics/Fast-RTPS/pull/1.

Signed-off-by: artivis <jeremie.deray@canonical.com>